### PR TITLE
bugfix: switch Math.round to Math.trunc to avoid round to major value

### DIFF
--- a/src/handlers/ShifumiHandler.ts
+++ b/src/handlers/ShifumiHandler.ts
@@ -48,7 +48,7 @@ class ShifumiHandler extends Handler {
    * Choose a random value
    */
   private pickRandomChoice(): ShifumiEnum {
-    return ShifumiHandler.availableValues[Math.round(ShifumiHandler.availableValues.length * Math.random())]
+    return ShifumiHandler.availableValues[Math.trunc(ShifumiHandler.availableValues.length * Math.random())]
   }
 }
 


### PR DESCRIPTION
Math.round() can round the value to major integer (e.g if value is 2.63, its rounded to 3) 
The array start to 0, so the index 3 is unknown because we only have indexes [0,1,2]. Math trunc will truncate the decimals so 2.63 will become 2 🎉 