### PR TITLE
Add whitelist and remove message with attachment if there is a text

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,24 @@ Chain the build and start command
 |ping|Answer pong|
 |!pp username|Get the profile picture URI|
 |!shifumi pierre&#124;feuille&#124;ciseaux|To play rock-paper-cissors with the bot|
+
+A meme channel is created depending on the env variable MEME_CHANNEL
+If you already have a channel which includes the name specified in the MEME_CHANNEL, it will use it (it avoids to create the same channel after each restart of the bot).
+
+The meme channel accepts urls finishing by .jpg, .jpeg, .gif, .png and .bmp, the message with an image (and no text) or the link from the whitelist which is tenor.com, giphy.com and imgur.com.
+
+## Initialization of the project
+
+Copy the .env.dist as a .env
+
+|Env Variable|Description|
+|---|---|
+|BOT_TOKEN|The token of the bot|
+|MEME_CHANNEL|The name of the meme channel (should only include it, not be exactly named like that)|
+
+Go to your [discord applications](https://discordapp.com/developers/applications) and create a new app
+Find your bot token in the bot menu
+To make your bot join your server, go in the OAuth menu
+Check "Bot"
+Check "Manage Channels" and "Manage Messages"
+Copy the url provided and use it to add the bot to your server

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "npm run build && npm run start",
-    "build": "mkdir -p dist && rm -rf dist/* && tsc --project tsconfig.json",
+    "build": "rm -rf dist && mkdir dist && tsc --project tsconfig.json",
     "start": "node dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/handlers/MemeHandler.ts
+++ b/src/handlers/MemeHandler.ts
@@ -3,12 +3,29 @@ import messageHelper from '../helpers/messageHelper'
 import Handler from './Handler'
 
 class MemeCheckerHandler extends Handler {
+  authorizedWebsites: string[]
+
+  constructor () {
+    super()
+    this.authorizedWebsites = [
+      'tenor.com',
+      'imgur.com',
+      'giphy.com'
+    ]
+  }
+
   validate(client: Client, msg: Message): boolean {
     return super.validate(client, msg) && messageHelper.isMemeChannel(msg)
   }
 
   async process(client: Client, msg: Message): Promise<boolean> {
-    if (!messageHelper.isUrl(msg) && !messageHelper.isValidImageFormat(msg.content) && msg.attachments.size === 0) {
+    let keepMsg = false
+
+    keepMsg = keepMsg || (msg.attachments.size > 0 && msg.content === '')
+    keepMsg = keepMsg || (messageHelper.isUrl(msg) && messageHelper.isValidImageFormat(msg.content))
+    keepMsg = keepMsg || (messageHelper.isUrl(msg) && messageHelper.isWhitelistedHostname(msg.content, this.authorizedWebsites))
+
+    if (!keepMsg) {
       msg.delete()
     }
     return true

--- a/src/helpers/messageHelper.ts
+++ b/src/helpers/messageHelper.ts
@@ -34,7 +34,7 @@ export default {
   },
   /**
    * Check if the argument is has a valid extension
-   * @param msg The message to analyse
+   * @param url The url to analyse
    */
   isValidImageFormat(url: string): boolean {
     const authorizedExtension = [
@@ -50,8 +50,8 @@ export default {
   },
   /**
    * Check if the url is included in the whitelist
-   * @param msg The message to analyse
-   * @param whitelist The list of the valid hostname
+   * @param url The url to analyse
+   * @param whitelist The list of the valid hostnames
    */
   isWhitelistedHostname(url: string, whitelist: string[]): boolean {
     const parsedUrl: UrlWithStringQuery = parse(url)

--- a/src/helpers/messageHelper.ts
+++ b/src/helpers/messageHelper.ts
@@ -47,5 +47,17 @@ export default {
     const parsedUrl: UrlWithStringQuery = parse(url)
 
     return parsedUrl.pathname && authorizedExtension.includes(extname(parsedUrl.pathname))
+  },
+  /**
+   * Check if the url is included in the whitelist
+   * @param msg The message to analyse
+   * @param whitelist The list of the valid hostname
+   */
+  isWhitelistedHostname(url: string, whitelist: string[]): boolean {
+    const parsedUrl: UrlWithStringQuery = parse(url)
+
+    return parsedUrl.hostname && whitelist.reduce((accumulator, hostname) => {
+      return accumulator || parsedUrl.hostname.endsWith(hostname)
+    }, false)
   }
 }


### PR DESCRIPTION
The whitelist allows links from giphy, tenor and imgur
The messages with attachment were authorized even if there were text with it. Now they are remove too.
Only image or link are allowed
Add informations in the README to explain how to use the bot 'locally'

Resolves : #3 