### PR TITLE
Fix the regex for the poll feature

### DIFF
--- a/src/helpers/parsingHelper.ts
+++ b/src/helpers/parsingHelper.ts
@@ -9,7 +9,7 @@ export default {
    * @param message The content of the message
    */
   parsePollMessage (message: string): Array<string> | null {
-    const matches = message.match(/\[([A-Za-zÀ-ÿ0-9\s\?_\-'"\.]+)\]/g)
+    const matches = message.match(/\[([^\[\]]+)\]/g)
     
     if (!matches || matches.length < 3) {
       return null


### PR DESCRIPTION
The selector `[^\[\]]` means every characters except [ and ]

You can test it with : https://regex101.com/r/wnyhuh/1